### PR TITLE
✨ feat: Add Quotation class and associated templates for PDF generation #4

### DIFF
--- a/src/Controllers/Quotation.php
+++ b/src/Controllers/Quotation.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Turbotech\PDFTemplate\Controllers;
+
+use Mpdf\Mpdf;
+use Illuminate\Support\Facades\View;
+use Turbotech\PDFTemplate\Controllers\Template;
+
+class Quotation extends Template
+{
+    protected $params;
+
+    public function __construct(?object $params = null)
+    {
+        $this->params = $params;
+        $this->render();
+    }
+
+    /**
+     * Get custom parameters for the quotation.
+     *
+     * @return object
+     */
+    public function getCustom()
+    {
+        return (object)[
+            "options" => array_merge(
+                [
+                    "orientation" => $this->params->options->orientation ?? "L",
+                    "title" => $this->params->options->title ?? "Quotation",
+                    "logo" => request()->get('header_image', self::$imageDir . self::$defaultHeaderImage),
+                ],
+                (array)($this->params->options ?? []),
+            ),
+            'header' => (object)[
+                "use_template" => $this->params->header->use_template ?? true,
+                "template" => [
+                    "name" => $this->params->header->template->name ?? "quotation"
+                ],
+                "view" => $this->params->header->view ?? null,
+            ],
+            'body' => $this->params->body ?? self::view(self::$views['quotation-example']),
+            'footer' => (object)[
+                "options" => (object)[],
+                "use_template" => $this->params->footer->use_template ?? true,
+                "template" => [
+                    "name" => $this->params->footer->template->name ?? "quotation"
+                ],
+                "view" => $this->params->footer->view ?? null,
+            ],
+        ];
+    }
+
+    /**
+     * Get the template name.
+     *
+     * @return string
+     */
+    public function getTemplateName()
+    {
+        return [
+            "header" => 'headers/quotation.blade.php',
+            "footer" => 'footers/quotation.blade.php'
+        ];
+    }
+
+    /**
+     * Get the template view.
+     *
+     * @return string
+     */
+    public function getTemplateView($type = 'header')
+    {
+        $params = (object)$this->getCustom()->options ?? (object)[];
+        return View::file("{$this->getTemplateDir()}{$this->getTemplateName()[$type]}", compact('params'))->render();
+    }
+
+    /**
+     * Get the header view.
+     *
+     * @return string
+     */
+    public function getHeader()
+    {
+        $params = $this->getCustom();
+        return $params->header->use_template
+            ? $this->getTemplateView('header')
+            : $params->header->view ?? "No header view provided";
+    }
+
+
+    /**
+     * Get the footer view.
+     *
+     * @return string
+     */
+    public function getFooter()
+    {
+        $params = $this->getCustom();
+        return $params->footer->use_template
+            ? $this->getTemplateView('footer')
+            : $params->footer->view ?? "No footer view provided";
+    }
+
+    /**
+     * Get the body view.
+     *
+     * @return string
+     */
+    public function getBody()
+    {
+        $params = $this->getCustom();
+        return $params->body ?? "No body view provided";
+    }
+
+
+    /**
+     * Render the PDF.
+     *
+     * @return void
+     */
+    public function render()
+    {
+        $rows = request()->get('rows', 14);
+        $cols = request()->get('cols', 20);
+        $title = request()->input('header_title', 'PDF');
+        $orentation = request()->get('orientation', request()->get('o', "L"));
+
+
+        $isLandscape = $orentation == "L" ? true : false;
+        $rowLimit = 16;
+
+        if (!$isLandscape) {
+            $rowLimit = 28;
+        }
+
+        $config = self::config([
+            'orientation' => $orentation,
+            'margin_bottom' => $rows < $rowLimit ? ($isLandscape ? 54 : 10) : 14,
+        ]);
+
+        $pdfTitle = $title . "_R{$rows}C{$cols}" . "_" . date('dmY_His');
+
+        $mpdf = new Mpdf($config);
+        $mpdf->SetTitle($pdfTitle);
+        $mpdf->SetAuthor(env('APP_NAME'));
+        $mpdf->SetCreator(env('APP_NAME'));
+        $mpdf->SetDisplayMode('fullpage');
+        $mpdf->SetProtection(['copy', 'print'], '', 'pass');
+        $mpdf->SetCompression(true);
+
+        $header = $this->getHeader();
+        $body = $this->getBody();
+        $footer = $this->getFooter();
+
+        $mpdf->WriteHTML("
+            <!DOCTYPE html>
+            <html lang='en'>
+            <head>
+                <meta charset='UTF-8'>
+                <title>{$pdfTitle}</title>
+                <style>
+                    .rounded-box {
+                        width: 100%;
+                        height: auto;
+                        line-height: 1.5rem;
+                        text-align: center;
+                        border-radius: 30px;
+                        border: 1px solid #1fa8e0;
+                    }
+                </style>
+            </head>
+            <body>
+                {$header} {$body}
+            </body>
+            </html>"
+        );
+
+        $mpdf->SetHTMLFooter($footer);
+        $mpdf->Output($pdfTitle . '.pdf', 'I');
+    }
+}

--- a/src/Controllers/Template.php
+++ b/src/Controllers/Template.php
@@ -19,7 +19,18 @@ class Template
         'header' => 'header.blade.php',
         'footer' => 'footer.blade.php',
         'body' => 'body.blade.php',
+        'quotation-example' => 'quotation-example.blade.php',
     ];
+
+    public static function getViewDir(): string
+    {
+        return __DIR__ . '/../views/';
+    }
+
+    public static function getTemplateDir(): string
+    {
+        return self::getViewDir() . 'templates/';
+    }
 
     public static function view(string $viewName, array $data = []): string
     {

--- a/src/views/example/quotation-example.blade.php
+++ b/src/views/example/quotation-example.blade.php
@@ -1,0 +1,114 @@
+<table style="margin-top: 1rem; font-size: 13px; width: 850px; border-collapse: collapse;">
+    <tr>
+        <td style="width: 50%; text-align: left; line-height: 1.5rem;">
+            <h2 style="font-size: 13px">Account/Customer: CHHUN ON GOLF RESORT</h2>
+            <p style="font-size: 12px">Contact Name: SORN SOKCHEA</p>
+            <p style="font-size: 12px; padding-top: 15px;">Address: Street N/A, Village Slaeng Meanchey, Commune Chhve</p>
+            <p style="font-size: 12px">Mobile: 070 634 296</p>
+        </td>
+        <td style="width: 50%; text-align: left; padding-left: 20px;line-height: 1.5rem;">
+            <h2 style="font-size: 13px">Ship To: CHHUN ON GOLF RESORT</h2>
+            <p style="font-size: 12px; padding-top: 15px;">Contact Name: SORN SOKCHEA</p>
+            <p style="font-size: 12px">Address: Street N/A, Village Slaeng Meanchey, Commune Chhv</p>
+            <p style="font-size: 12px">Mobile: 070 634 296</p>
+        </td>
+    </tr>
+</table>
+
+<table style="margin-top: 1rem; font-size: 13px; width: 850px; border-collapse: collapse;">
+    <tr style=" border: 1px solid #1fa8e0;">
+        <td style="border: 1px solid #1fa8e0; padding-left: 5px; padding-right: 5px; text-align: left; line-height: 1.5rem; width: 350px;"> PO Number: </td>
+        <td style="border: 1px solid #1fa8e0; padding-left: 5px; padding-right: 5px; text-align: left; padding-left: 20px;line-height: 1.5rem;"> Reference:</td>
+        <td style="border: 1px solid #1fa8e0; padding-left: 5px; padding-right: 5px; text-align: left; padding-left: 20px;line-height: 1.5rem; width: 350px;"></td>
+    </tr>
+</table>
+
+<table border="1" style="margin-top: 1rem; font-size: 13px; width: 850px; border-collapse: collapse;">
+    <thead>
+        <tr style="background-color: #1fa8e0; color: white; text-align: center;">
+            <th style="padding: 7px; line-height: 1.5rem; width: 40px;">No.</th>
+            <th style="padding: 7px; line-height: 1.5rem; width: 125px;">Code/Picture</th>
+            <th style="padding: 7px; line-height: 1.5rem;">Description</th>
+            <th style="padding: 7px; line-height: 1.5rem; text-align: right;  width: 90px;">Price</th>
+            <th style="padding: 7px; line-height: 1.5rem; width: 50px;">QTY</th>
+            <th style="padding: 7px; line-height: 1.5rem; width: 50px;">U/M</th>
+            <th style="padding: 7px; line-height: 1.5rem; text-align: right; width: 80px;">Disc. ($)</th>
+            <th style="padding: 7px; line-height: 1.5rem; text-align: right;  width: 110px;">Total Amount</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td style="text-align: center; line-height: 1.5rem; padding: 5px;">1</td>
+            <td style="text-align: center; line-height: 1.5rem; padding: 5px;">PO-00001</td>
+            <td style="text-align: left; line-height: 1.5rem; padding: 5px;">Example Description</td>
+            <td style="text-align: right; line-height: 1.5rem; padding: 5px;">$100.00</td>
+            <td style="text-align: right; line-height: 1.5rem; padding: 5px;">2</td>
+            <td style="text-align: center; line-height: 1.5rem; padding: 5px;">pcs</td>
+            <td style="text-align: right; line-height: 1.5rem; padding: 5px;">$0.00</td>
+            <td style="text-align: right; line-height: 1.5rem; padding: 5px;">$200.00</td>
+        </tr>
+        <tr>
+            <td style="height: 20px; border-right: none;"></td>
+            <td style="border: none;"></td>
+            <td style="border: none;"></td>
+            <td style="border: none;"></td>
+            <td style="border: none;"></td>
+            <td style="border: none;"></td>
+            <td style="border: none;"></td>
+            <td style="border-left: none;"></td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <td colspan="6" style="background-color: #1fa8e0; text-align: center; border: none; border-left: 1px solid black; border-top: 1px solid black;"></td>
+            <td style="background-color: #1fa8e0; text-align: center; border: none; border-top: 1px solid black; font-weight: bold; padding-top: 7px;">Total</td>
+            <td style="background-color: #1fa8e0; text-align: center; border: none; border-top: 1px solid black; border-right: 1px solid black; font-weight: bold; text-align: right; padding-top: 7px; padding-right: 7px">$200.00</td>
+        </tr>
+        <tr>
+            <td colspan="6" style="background-color: #1fa8e0; text-align: center; border: none; border-left: 1px solid black;"></td>
+            <td style="background-color: #1fa8e0; text-align: center; border: none; font-weight: bold">Discount</td>
+            <td style="background-color: #1fa8e0; text-align: center; border: none; border-right: 1px solid black; font-weight: bold; text-align: right; padding-right: 7px;">$0.00</td>
+        </tr>
+        <tr>
+            <td colspan="6" style="background-color: #1fa8e0; text-align: center; border: none; border-left: 1px solid black;"></td>
+            <td style="background-color: #1fa8e0; text-align: center; border: none; font-weight: bold">VAT (10%)</td>
+            <td style="background-color: #1fa8e0; text-align: center; border: none; border-right: 1px solid black; font-weight: bold; text-align: right; padding-right: 7px;">$0.00</td>
+        </tr>
+        <tr>
+            <td colspan="6" style="background-color: #1fa8e0; text-align: center; border: none; border-left: 1px solid black; border-bottom: 1px solid black;"></td>
+            <td style="background-color: #1fa8e0; text-align: center; border: none; border-bottom: 1px solid black; font-weight: bold; white-space: nowrap;">Grand Total</td>
+            <td style="background-color: #1fa8e0; text-align: center; border: none; border-bottom: 1px solid black; border-right: 1px solid black; font-weight: bold; text-align: right; padding-bottom: 7px; padding-right: 7px">$200.00</td>
+        </tr>
+    </tfoot>
+</table>
+
+
+<table style="margin-top: 1rem; font-size: 11px; width: 850px; border-collapse: collapse;">
+    <tr>
+        <td colspan="2" style="font-weight: bold; padding: 5px 0;">Term & Condition:</td>
+    </tr>
+    <tr>
+        <td style="vertical-align: top; width: 10px;">-</td>
+        <td style="padding-bottom: 2px;">Payment Term 100% after product delivery for 1 Week</td>
+    </tr>
+    <tr>
+        <td style="vertical-align: top;">-</td>
+        <td style="padding-bottom: 2px;">Delivery: Based on each item.</td>
+    </tr>
+    <tr>
+        <td style="vertical-align: top;">-</td>
+        <td style="padding-bottom: 2px;">Warranty: Warranty 1 year</td>
+    </tr>
+    <tr>
+        <td style="vertical-align: top;">-</td>
+        <td style="padding-bottom: 2px;">Implement: 1 Week during working days after signing to confirm on Quotation</td>
+    </tr>
+    <tr>
+        <td style="vertical-align: top;">-</td>
+        <td style="padding-bottom: 2px;">Cancellation: In case, the PO is cancelled after confirmation, full payment must be honored by the customer.</td>
+    </tr>
+    <tr>
+        <td style="vertical-align: top;">-</td>
+        <td style="padding-bottom: 2px;">Note: Customer must check goods at the time of delivery. Goods sold are not returnable and refundable</td>
+    </tr>
+</table>

--- a/src/views/templates/footers/quotation.blade.php
+++ b/src/views/templates/footers/quotation.blade.php
@@ -1,0 +1,30 @@
+@php
+    $params = (object) $params;
+    $isLandscape = strtoupper($params->orientation) == 'L';
+@endphp
+
+<table style="width: 850px; margin-bottom: 7rem; font-size: 16px; ">
+    <tr>
+        <th style="width: 120px;"></th>
+        <th style="text-align: center; padding: 1rem; border-top: 2px solid #1fa8e0;">
+            <div style="font-size: 14px; margin-top: 0.5rem;">
+                Authorize Signature
+            </div>
+        </th>
+        <th style="width: 120px;"></th>
+        <th style="text-align: center; padding: 1rem; border-top: 2px solid #1fa8e0;">
+            <div style="font-size: 14px; margin-top: 0.5rem;">
+                Customer Signature
+            </div>
+        </th>
+        <th style="width: 120px;"></th>
+    </tr>
+</table>
+
+<table style="width: 850px; font-size: 11px; margin-bottom: 1rem;">
+    <tr>
+        <th style="text-align: center; padding: 5px; background: #1fa8e0;">
+            ONE-STOP TECHNOLOGY SOLUTIONS
+        </th>
+    </tr>
+</table>

--- a/src/views/templates/footers/reporting.blade.php
+++ b/src/views/templates/footers/reporting.blade.php
@@ -1,0 +1,42 @@
+@php
+    $isLanscape = strtoupper($header->orientation) == 'L';
+    $titleLength = strlen($header->title ?? '');
+
+    $lineHeight = 35;
+    $marginTop = -5;
+
+    $companySize = 20;
+    $titleSize = 16;
+    $periodSize = 14;
+
+    if (!$isLanscape) {
+        $lineHeight = $titleLength > 35 ? 28 : 35;
+        $marginTop = $titleLength > 35 ? -4.8 : -5;
+
+        // $companySize = $titleLength > 35 ? 18 : 20;
+        // $titleSize = $titleLength > 35 ? 14 : 16;
+        // $periodSize = $titleLength > 35 ? 12 : 14;
+    }
+
+@endphp
+<table style="width:100%; margin-top: 20rem; margin-bottom: 0.75rem;">
+    <tr>
+        <td style="width: 20%; text-align: center;">
+            @if(isset($headerImage) && $headerImage)
+            <img style="width: 190px; margin-top:-80px; margin-left:-5px" src="{{ $headerImage }}" />
+            @endif
+        </td>
+
+        <td style="width:80%;">
+            <table style="width:100%; text-align:center; margin-right: 10rem; margin-top: {{ $marginTop }}rem;">
+                <tr style="width:100%;text-align:center;">
+                    <td style="text-align:center;width:100%; line-height: 24px;">
+                        <h1 style="font-size:{{ $companySize }}px; font-weight: bold">{{ $header->company ?? '' }}</h1>
+                        <h2 style="font-size:{{ $titleSize }}px; font-weight: bold;">{{ $header->title ?? '' }}</h2>
+                        <h3 style="font-size:{{ $periodSize }}px; font-weight: bold">{{ $header->period ?? '' }}</h3>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>

--- a/src/views/templates/headers/quotation.blade.php
+++ b/src/views/templates/headers/quotation.blade.php
@@ -1,0 +1,82 @@
+@php
+    $params = (object) $params;
+    $isLanscape = strtoupper(($params->orientation ?? "")) === 'L';
+    $titleLength = strlen($params->title ?? '');
+    $marginTop = -5;
+
+    if (!$isLanscape) {
+        $marginTop = $titleLength > 35 ? -4.8 : -5;
+    }
+
+    $logo = $params->logo ?? null;
+
+    $company = (object) array_merge(
+        (array)[
+            "name" => "TURBOTECH CO., LTD.",
+            "address" => "N/A",
+            "phone" => "N/A",
+            "email" => "N/A",
+            "website" => "www.turbotech.com.kh"
+        ],
+        (array) ($params->company ?? [])
+    );
+
+    $sales = (object) array_merge(
+        (array)[
+            "name" => "N/A",
+            "phone" => "N/A",
+            "email" => "N/A"
+        ],
+        (array) ($params->sales ?? [])
+    );
+
+    $quotation = (object) array_merge(
+        (array)[
+            "number" => "N/A",
+            "currency" => "USD",
+            "created_date" => null,
+            "expire_date" => null
+        ],
+        (array) ($params->quotation ?? [])
+    );
+@endphp
+
+
+<table style="width:100%; margin-top: 20rem; margin-bottom: 0.75rem;">
+    <tr>
+        <td style="text-align: center;">
+            @if(isset($logo) && $logo)
+                <img style="width: 170px; margin-top:-85px;" src="{{ $logo }}" />
+            @endif
+        </td>
+
+        <td style="width: 750px">
+            <table width="100%" style="margin-top: {{ $marginTop }}rem; width: 100%; margin-left: 10px; text-align:left; border-collapse: collapse;">
+                <tr>
+                    <td style="width: 210px; line-height: 20px">
+                        <h1 style="font-size: 16px; font-weight: bold;">{{ $company->name ?? 'TURBOTECH CO., LTD.' }}</h1>
+                        <p style="font-size: 14px">Address: {{ $company->address }}</p>
+                        <p style="font-size: 14px">Phone:  {{ $company->phone }}</p>
+                        <p style="font-size: 14px">E-mail: {{ $company->email }}</p>
+                        <p style="font-size: 14px">{{ $company->website ?? 'www.turbotech.com.kh' }}</p>
+                    </td>
+                    <td style="width: 200px; text-align: left; padding-left: 15px;  line-height: 20px">
+                        <h1 style="font-size: 14px; font-weight: bold;">Sales Rep: {{ $sales->name }}</h1>
+                        <p style="font-size: 14px">Mobile: {{ $sales->phone }}</p>
+                        <p style="font-size: 14px">E-mail: {{ $sales->email }}</p>
+                    </td>
+                    <td style="width: 120px; text-align: left; line-height: 20px; white-space: nowrap;">
+                        <p style="font-size: 14px; white-space: nowrap;">Quote Number: {{ $quotation->number}}</p>
+                        <p style="font-size: 14px; white-space: nowrap;">Currency Code: {{ $quotation->currency}}</p>
+                        <p style="font-size: 14px; white-space: nowrap;">Quotation Date: {{ $quotation->created_date ? date("d/m/Y", strtotime($quotation->created_date)) : 'N/A' }}</p>
+                        <p style="font-size: 14px; white-space: nowrap;">Expire Date: {{ $quotation->expire_date ? date("d/m/Y", strtotime($quotation->expire_date)) : 'N/A' }}</p>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+
+<div class="rounded-box" style="width: 100%; font-size: 12px; font-weight: bold;">
+    {{ strtoupper($params->title ?? 'Quotation') }}
+</div>

--- a/src/views/templates/headers/reporting.blade.php
+++ b/src/views/templates/headers/reporting.blade.php
@@ -1,0 +1,42 @@
+@php
+    $isLanscape = strtoupper($header->orientation) == 'L';
+    $titleLength = strlen($header->title ?? '');
+
+    $lineHeight = 35;
+    $marginTop = -5;
+
+    $companySize = 20;
+    $titleSize = 16;
+    $periodSize = 14;
+
+    if (!$isLanscape) {
+        $lineHeight = $titleLength > 35 ? 28 : 35;
+        $marginTop = $titleLength > 35 ? -4.8 : -5;
+
+        // $companySize = $titleLength > 35 ? 18 : 20;
+        // $titleSize = $titleLength > 35 ? 14 : 16;
+        // $periodSize = $titleLength > 35 ? 12 : 14;
+    }
+
+@endphp
+<table style="width:100%; margin-top: 20rem; margin-bottom: 0.75rem;">
+    <tr>
+        <td style="width: 20%; text-align: center;">
+            @if(isset($headerImage) && $headerImage)
+            <img style="width: 190px; margin-top:-80px; margin-left:-5px" src="{{ $headerImage }}" />
+            @endif
+        </td>
+
+        <td style="width:80%;">
+            <table style="width:100%; text-align:center; margin-right: 10rem; margin-top: {{ $marginTop }}rem;">
+                <tr style="width:100%;text-align:center;">
+                    <td style="text-align:center;width:100%; line-height: 24px;">
+                        <h1 style="font-size:{{ $companySize }}px; font-weight: bold">{{ $header->company ?? '' }}</h1>
+                        <h2 style="font-size:{{ $titleSize }}px; font-weight: bold;">{{ $header->title ?? '' }}</h2>
+                        <h3 style="font-size:{{ $periodSize }}px; font-weight: bold">{{ $header->period ?? '' }}</h3>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>


### PR DESCRIPTION
This pull request introduces a new PDF generation feature for quotations, including the implementation of a `Quotation` class, updates to the `Template` class, and the addition of new Blade templates for headers, footers, and body content. The key changes are grouped into the following themes:

### New Quotation PDF Generation Feature:
* Added a new `Quotation` class in `src/Controllers/Quotation.php` to handle PDF generation for quotations. This includes methods for setting custom parameters, rendering templates, and generating the PDF with headers, body, and footers. (`[src/Controllers/Quotation.phpR1-R182](diffhunk://#diff-0920e6eb86313664d6a4e9f3fdb26b4f247c009aab739396f409ba57ce3bdbf8R1-R182)`)

### Template Enhancements:
* Updated the `Template` class in `src/Controllers/Template.php` to include new utility methods (`getViewDir`, `getTemplateDir`) and support for a `quotation-example` view. (`[src/Controllers/Template.phpR22-R34](diffhunk://#diff-aec4b5f22f63b8b7ffa7240e20105c02024db9d66b135cc7b053bbe2939c642bR22-R34)`)

### Blade Templates for Quotation:
* Added a new `quotation-example.blade.php` template for the body of the quotation PDF, including detailed sections for customer details, order details, and terms and conditions. (`[src/views/example/quotation-example.blade.phpR1-R114](diffhunk://#diff-d2c6429399cf585200f18d58cba8ac60a1753299108b72624e0e937759e76655R1-R114)`)
* Added `headers/quotation.blade.php` and `footers/quotation.blade.php` templates for the quotation's header and footer, respectively, with dynamic placeholders for company, sales, and quotation details. (`[[1]](diffhunk://#diff-0beb6e56712bcb44f18451e53c7bffe81b917ed6f38c7f9381da7da4a7c576b0R1-R82)`, `[[2]](diffhunk://#diff-d200aeb47724be59044f3eb5ccfad3b5e99f8bd9586f4fe7761757c06ae76b27R1-R30)`)

### General Template Updates:
* Added new templates for reporting headers and footers (`headers/reporting.blade.php`, `footers/reporting.blade.php`) to support additional use cases. (`[src/views/templates/footers/reporting.blade.phpR1-R42](diffhunk://#diff-2e22669722787458747b26f708d50b942a353509629e97cc702c1cb2e174c556R1-R42)`)