### PR TITLE
✨ docs: Update links in documentation for PDF and Template test cases

### DIFF
--- a/docs/pdf.md
+++ b/docs/pdf.md
@@ -1,7 +1,5 @@
 ## PDF Class Usage Example
 
-The [`PDF`](src/PDFs/PDF.php) class provides a flexible way to generate PDFs with custom configuration and templates. Below are usage examples that match the tested behaviors in [`PDFTest`](tests/Unit/PDFTest.php):
-
 ### Basic Instantiation and Configuration
 
 ```php

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,7 +1,5 @@
 ## Template Class Test Case Examples (Old version)
 
-The [`Template`](src/Controllers/Template.php) class provides static methods for PDF configuration and rendering. Below are usage examples that match the tested behaviors in [`TemplateTest`](tests/Unit/TemplateTest.php):
-
 ### Basic Configuration
 
 ```php


### PR DESCRIPTION
✨ docs: Update links in documentation for PDF and Template test cases
This pull request makes minor documentation updates to improve clarity by removing redundant introductory sentences in the usage examples for the `PDF` and `Template` classes.

* [`docs/pdf.md`](diffhunk://#diff-744f56a3590dac0f92052e7d3683773831d366d063fa9f03b67ae342da0cf35eL3-L4): Removed redundant description of the `PDF` class and its tested behaviors in the usage example section.
* [`docs/template.md`](diffhunk://#diff-402df3bcefa44a9f9e2b52fe5f28ac421f7e06cbdc02ef22b5e2dac029da4d89L3-L4): Removed redundant description of the `Template` class and its tested behaviors in the usage example section.